### PR TITLE
Reorganise data into separate languages

### DIFF
--- a/database/schedule.js
+++ b/database/schedule.js
@@ -54,7 +54,7 @@ export const scrapeWeek = async ({ weekID, language }) => {
   const query = { _id: ObjectID(weekID) }
   const week = await coll.findOne(query)
   assert.notStrictEqual(null, week, 'Week ID does not exist')
-  const update = { $set: { [language]: await scrapeWOL(week.date) } }
+  const update = { $set: await scrapeWOL(week.date, language) }
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 'Update not successful')
   return value

--- a/database/schedule.js
+++ b/database/schedule.js
@@ -151,7 +151,8 @@ export const updateWeekType = async ({ weekID, language, type }) => {
   }
 
   // Update Type
-  Object.assign(update.$set, { type })
+  const updatePath = language + '.type'
+  Object.assign(update.$set, { [updatePath]: type })
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 404)
 

--- a/database/schedule.js
+++ b/database/schedule.js
@@ -140,8 +140,7 @@ export const updateWeekType = async ({ weekID, language, type }) => {
   // Check the previous week didn't already have the same type
   const baseWeek = await coll.findOne(query)
   assert.notStrictEqual(null, baseWeek, 404)
-  const week = baseWeek[language] || null
-  assert.notStrictEqual(null, week, 404)
+  const week = baseWeek[language] || {}
   assert.notStrictEqual(type, week.type, 400)
 
   // Remove existing assigned members if necessary

--- a/database/schedule.js
+++ b/database/schedule.js
@@ -90,7 +90,7 @@ export const updateAssignment = async ({ weekID, language, name, assignment }) =
 
   // Add newly assigned members
   for (const field of ASSIGNEE_FIELDS) {
-    const memberID = value.assignments[name][field]
+    const memberID = value[language].assignments[name][field]
     if (memberID) {
       const member = await addAssignment({ memberID, assignment: { type: assignment.type, date: value.date } })
       updatedMembers.push(member)

--- a/database/schedule.js
+++ b/database/schedule.js
@@ -3,7 +3,7 @@ import assert from 'assert'
 import setup from './setup'
 import scrapeWOL from './scraper'
 import { addAssignment, removeAssignment } from './congregation'
-import { WEEK_TYPES } from '../src/constants'
+import { WEEK_TYPES, SUPPORTED_LANGUAGES } from '../src/constants'
 
 const ASSIGNEE_FIELDS = ['assignee', 'assistant']
 
@@ -19,7 +19,11 @@ export const getWeek = async ({ date }) => {
   const existingWeek = await coll.findOne(query)
   if (existingWeek) return existingWeek
   // if week doesn't exist add it and return the added week
-  const newWeekResult = await coll.insertOne({ date, assignments: {} })
+  const baseWeek = { date }
+  for (const { value } of SUPPORTED_LANGUAGES) {
+    baseWeek[value] = { assignments: {} }
+  }
+  const newWeekResult = await coll.insertOne(baseWeek)
   const newWeek = newWeekResult && newWeekResult.ops && newWeekResult.ops[0]
   assert.notStrictEqual(null, newWeek, 'Adding Missing Week was unsuccessful')
   return newWeek
@@ -45,31 +49,33 @@ export const getMonth = async ({ month }) => {
   return weeks
 }
 
-export const scrapeWeek = async ({ weekID }) => {
+export const scrapeWeek = async ({ weekID, language }) => {
   const coll = await getCollection
   const query = { _id: ObjectID(weekID) }
   const week = await coll.findOne(query)
   assert.notStrictEqual(null, week, 'Week ID does not exist')
-  const update = { $set: await scrapeWOL(week.date) }
+  const update = { $set: { [language]: await scrapeWOL(week.date) } }
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 'Update not successful')
   return value
 }
 
-export const updateAssignment = async ({ weekID, name, assignment }) => {
+export const updateAssignment = async ({ weekID, language, name, assignment }) => {
   const coll = await getCollection
   const query = { _id: ObjectID(weekID) }
 
   // Remove existing assigned members
   const updatedMembers = []
-  const week = await coll.findOne(query)
+  const baseWeek = await coll.findOne(query)
+  assert.notStrictEqual(null, baseWeek, 404)
+  const week = baseWeek[language] || null
   assert.notStrictEqual(null, week, 404)
   const previousAssignment = week.assignments[name]
   if (previousAssignment) {
     for (const field of ASSIGNEE_FIELDS) {
       const memberID = previousAssignment[field]
       if (memberID) {
-        const member = await removeAssignment({ memberID, assignment: { type: previousAssignment.type, date: week.date } })
+        const member = await removeAssignment({ memberID, assignment: { type: previousAssignment.type, date: baseWeek.date } })
         updatedMembers.push(member)
       }
     }
@@ -77,7 +83,7 @@ export const updateAssignment = async ({ weekID, name, assignment }) => {
 
   // Update Assignment
   const update = {}
-  const assignmentPath = 'assignments.' + name
+  const assignmentPath = language + '.assignments.' + name
   update.$set = { [assignmentPath]: assignment }
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 404)
@@ -95,12 +101,14 @@ export const updateAssignment = async ({ weekID, name, assignment }) => {
   return { week: value, members: updatedMembers }
 }
 
-export const updateWeekType = async ({ weekID, type }) => {
+export const updateWeekType = async ({ weekID, language, type }) => {
   const coll = await getCollection
   const query = { _id: ObjectID(weekID) }
 
   // Check the previous week didn't already have the same type
-  const week = await coll.findOne(query)
+  const baseWeek = await coll.findOne(query)
+  assert.notStrictEqual(null, baseWeek, 404)
+  const week = baseWeek[language] || null
   assert.notStrictEqual(null, week, 404)
   assert.notStrictEqual(type, week.type, 400)
 
@@ -115,9 +123,9 @@ export const updateWeekType = async ({ weekID, type }) => {
           for (const field of ASSIGNEE_FIELDS) {
             const memberID = v[field]
             if (memberID) {
-              const member = await removeAssignment({ memberID, assignment: { type: v.type, date: week.date } })
+              const member = await removeAssignment({ memberID, assignment: { type: v.type, date: baseWeek.date } })
               updatedMembers.push(member)
-              const assignmentPath = `assignments.${k}.${field}`
+              const assignmentPath = `${language}.assignments.${k}.${field}`
               update.$set[assignmentPath] = null
             }
           }
@@ -132,9 +140,9 @@ export const updateWeekType = async ({ weekID, type }) => {
           for (const field of ASSIGNEE_FIELDS) {
             const memberID = assignment[field]
             if (memberID) {
-              const member = await removeAssignment({ memberID, assignment: { type: assignment.type, date: week.date } })
+              const member = await removeAssignment({ memberID, assignment: { type: assignment.type, date: baseWeek.date } })
               updatedMembers.push(member)
-              const assignmentPath = `assignments.${assignmentName}.${field}`
+              const assignmentPath = `${language}.assignments.${assignmentName}.${field}`
               update.$set[assignmentPath] = null
             }
           }
@@ -151,19 +159,21 @@ export const updateWeekType = async ({ weekID, type }) => {
   return { week: value, members: updatedMembers }
 }
 
-export const updateCOName = async ({ weekID, name }) => {
+export const updateCOName = async ({ weekID, language, name }) => {
   const coll = await getCollection
   const query = { _id: ObjectID(weekID) }
-  const update = { $set: { coName: name } }
+  const updatePath = language + '.coName'
+  const update = { $set: { [updatePath]: name } }
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 404)
   return value
 }
 
-export const updateCOTitle = async ({ weekID, title }) => {
+export const updateCOTitle = async ({ weekID, language, title }) => {
   const coll = await getCollection
   const query = { _id: ObjectID(weekID) }
-  const update = { $set: { coTitle: title } }
+  const updatePath = language + '.coTitle'
+  const update = { $set: { [updatePath]: title } }
   const { value } = await coll.findOneAndUpdate(query, update, { returnOriginal: false })
   assert.notStrictEqual(null, value, 404)
   return value

--- a/database/scraper.js
+++ b/database/scraper.js
@@ -85,7 +85,6 @@ export default function scrapeWOL (date, language) {
 
   // We allow for multiple uris because sometimes the url can change slightly for no obvious reason, so we try them all and catch the first that succeeds
   const uris = addressConstructor(date)
-  console.log(uris)
   return Promise.all(uris.map(uri => {
     return rp({ uri, transform })
       .then(

--- a/database/scraper.js
+++ b/database/scraper.js
@@ -3,6 +3,7 @@ import cheerio from 'cheerio'
 
 const LANGUAGE_OPTIONS = {
   en: {
+    months: ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'],
     addressConstructor: date => {
       return ['https://wol.jw.org/en/wol/dt/r1/lp-e/' + date.replace(/-/g, '/')]
     },
@@ -35,6 +36,9 @@ const LANGUAGE_OPTIONS = {
         workbookWeeks.push(sD + '-' + eD + sMonth)
         workbookWeeks.push(sD + 'a' + eD + '-' + sMonth)
         workbookWeeks.push(sD + '-' + eD + '-' + sMonth)
+        // just in case of an accidental english abbreviation instead (e.g. /programa-reuniao-22a28-apr/)
+        const englishMonth = LANGUAGE_OPTIONS.en.months[sM - 1].substr(0, 3)
+        workbookWeeks.push(sD + 'a' + eD + '-' + englishMonth)
       } else {
         const eMonth = months[eM - 1].substr(0, 3)
         workbookWeeks.push(sD + sMonth + '-' + eD + eMonth)
@@ -93,7 +97,10 @@ export default function scrapeWOL (date, language) {
       )
   }))
     .then(
-      () => { throw new Error('404') },
+      () => {
+        console.log('No URIs matched: ', uris)
+        throw new Error('404')
+      },
       val => Promise.resolve(val)
     )
     .then($ => {

--- a/database/upload.js
+++ b/database/upload.js
@@ -2,7 +2,7 @@ import parse from 'csv-parse/lib/sync'
 import fs from 'fs'
 import assert from 'assert'
 import { bulkAddMembers } from './congregation'
-import { APPOINTMENTS, GENDERS, LANGUAGE_GROUPS } from '../src/constants'
+import { APPOINTMENTS, GENDERS, SUPPORTED_LANGUAGES } from '../src/constants'
 
 const filename = process.argv[2]
 if (!filename) throw new Error('No file argument provided')
@@ -22,7 +22,7 @@ const columns = [
   { name: 'abbreviation', noDuplicates: true },
   { name: 'appointment', allowedValues: APPOINTMENTS },
   { name: 'gender', allowedValues: GENDERS },
-  { name: 'languageGroup', allowedValues: LANGUAGE_GROUPS },
+  { name: 'languageGroup', allowedValues: SUPPORTED_LANGUAGES.map(({ value }) => value) },
   { name: 'show', boolean: true },
   { name: 'privileges.chairman', boolean: true },
   { name: 'privileges.highlights', boolean: true },

--- a/lambda/api.js
+++ b/lambda/api.js
@@ -27,6 +27,10 @@ const handleErrors = res => error => {
   }
 }
 
+const validLanguage = language => {
+  return SUPPORTED_LANGUAGES.some(({ value }) => value === language)
+}
+
 router.post('/auth/login', (req, res) => {
   const { password } = req.body
   if (!password) return res.status(400).json({ message: 'No password provided' })
@@ -119,26 +123,29 @@ router.get('/schedule/month/:month', (req, res) => {
 })
 
 router.put('/schedule/scrape', (req, res) => {
-  const { weekID } = req.body
+  const { weekID, language } = req.body
   if (!weekID) return res.status(400).json({ message: 'weekID is required' })
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   schedule.scrapeWeek({ weekID })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
 
 router.put('/schedule/updateAssignment', (req, res) => {
-  const { weekID, name, assignment } = req.body
-  if (!weekID || !name || !assignment) {
-    return res.status(400).json({ message: 'Required Fields are: weekID, name, assignment' })
+  const { weekID, language, name, assignment } = req.body
+  if (!weekID || !language || !name || !assignment) {
+    return res.status(400).json({ message: 'Required Fields are: weekID, language, name, assignment' })
   }
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   schedule.updateAssignment({ weekID, name, assignment })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
 
 router.put('/schedule/updateWeekType', (req, res) => {
-  const { weekID, type } = req.body
-  if (!weekID || type === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, type' })
+  const { weekID, language, type } = req.body
+  if (!weekID || !language || type === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, type' })
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   if (!(Object.values(WEEK_TYPES).some(t => t.value === type))) return res.status(400).json({ message: 'Invalid Type' })
   schedule.updateWeekType({ weekID, type })
     .then(returnResult(res))
@@ -146,16 +153,18 @@ router.put('/schedule/updateWeekType', (req, res) => {
 })
 
 router.put('/schedule/updateCOName', (req, res) => {
-  const { weekID, name } = req.body
-  if (!weekID || name === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, name' })
+  const { weekID, language, name } = req.body
+  if (!weekID || !language || name === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, name' })
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   schedule.updateCOName({ weekID, name })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
 
 router.put('/schedule/updateCOTitle', (req, res) => {
-  const { weekID, title } = req.body
-  if (!weekID || title === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, title' })
+  const { weekID, language, title } = req.body
+  if (!weekID || !language || title === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, title' })
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   schedule.updateCOTitle({ weekID, title })
     .then(returnResult(res))
     .catch(handleErrors(res))

--- a/lambda/api.js
+++ b/lambda/api.js
@@ -126,7 +126,7 @@ router.put('/schedule/scrape', (req, res) => {
   const { weekID, language } = req.body
   if (!weekID) return res.status(400).json({ message: 'weekID is required' })
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
-  schedule.scrapeWeek({ weekID })
+  schedule.scrapeWeek({ weekID, language })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
@@ -137,7 +137,7 @@ router.put('/schedule/updateAssignment', (req, res) => {
     return res.status(400).json({ message: 'Required Fields are: weekID, language, name, assignment' })
   }
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
-  schedule.updateAssignment({ weekID, name, assignment })
+  schedule.updateAssignment({ weekID, language, name, assignment })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
@@ -147,7 +147,7 @@ router.put('/schedule/updateWeekType', (req, res) => {
   if (!weekID || !language || type === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, type' })
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   if (!(Object.values(WEEK_TYPES).some(t => t.value === type))) return res.status(400).json({ message: 'Invalid Type' })
-  schedule.updateWeekType({ weekID, type })
+  schedule.updateWeekType({ weekID, language, type })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
@@ -156,7 +156,7 @@ router.put('/schedule/updateCOName', (req, res) => {
   const { weekID, language, name } = req.body
   if (!weekID || !language || name === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, name' })
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
-  schedule.updateCOName({ weekID, name })
+  schedule.updateCOName({ weekID, language, name })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })
@@ -165,7 +165,7 @@ router.put('/schedule/updateCOTitle', (req, res) => {
   const { weekID, language, title } = req.body
   if (!weekID || !language || title === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, title' })
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
-  schedule.updateCOTitle({ weekID, title })
+  schedule.updateCOTitle({ weekID, language, title })
     .then(returnResult(res))
     .catch(handleErrors(res))
 })

--- a/lambda/api.js
+++ b/lambda/api.js
@@ -128,7 +128,11 @@ router.put('/schedule/scrape', (req, res) => {
   if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
   schedule.scrapeWeek({ weekID, language })
     .then(returnResult(res))
-    .catch(handleErrors(res))
+    .catch(err => {
+      const errorHandler = handleErrors(res)
+      if (err.status === 404) errorHandler(new Error('404'))
+      else errorHandler(err)
+    })
 })
 
 router.put('/schedule/updateAssignment', (req, res) => {

--- a/lambda/api.js
+++ b/lambda/api.js
@@ -142,6 +142,17 @@ router.put('/schedule/updateAssignment', (req, res) => {
     .catch(handleErrors(res))
 })
 
+router.put('/schedule/deleteAssignment', (req, res) => {
+  const { weekID, language, name } = req.body
+  if (!weekID || !language || !name) {
+    return res.status(400).json({ message: 'Required Fields are: weekID, language, name' })
+  }
+  if (!validLanguage(language)) return res.status(400).json({ message: 'Invalid language' })
+  schedule.deleteAssignment({ weekID, language, name })
+    .then(returnResult(res))
+    .catch(handleErrors(res))
+})
+
 router.put('/schedule/updateWeekType', (req, res) => {
   const { weekID, language, type } = req.body
   if (!weekID || !language || type === undefined) return res.status(400).json({ message: 'Required Fields are: weekID, language, type' })

--- a/lambda/api.js
+++ b/lambda/api.js
@@ -5,7 +5,7 @@ const serverless = require('serverless-http')
 const auth = require('../database/auth')
 const congregation = require('../database/congregation')
 const schedule = require('../database/schedule')
-const { APPOINTMENTS, GENDERS, LANGUAGE_GROUPS, WEEK_TYPES } = require('../src/constants')
+const { APPOINTMENTS, GENDERS, SUPPORTED_LANGUAGES, WEEK_TYPES } = require('../src/constants')
 
 // Initialize express app
 const app = express()
@@ -59,12 +59,13 @@ router.get('/congregation/members', (req, res) => {
     .catch(handleErrors(res))
 })
 
+const languageCodes = SUPPORTED_LANGUAGES.map(({ value }) => value)
 const validateMember = member => {
   const { name, abbreviation, appointment, gender, languageGroup, privileges, show } = member
   if (!name || !abbreviation) return 'Name & Abbreviation are required'
   if (!APPOINTMENTS.includes(appointment)) return 'Appointment must be one of the following: ' + APPOINTMENTS.join(', ')
   if (!GENDERS.includes(gender)) return 'Gender must be one of the following: ' + GENDERS.join(', ')
-  if (!LANGUAGE_GROUPS.includes(languageGroup)) return 'Language Group must be one of the following: ' + LANGUAGE_GROUPS.join(', ')
+  if (!languageCodes.includes(languageGroup)) return 'Language Group must be one of the following: ' + languageCodes.join(', ')
   if (!privileges || typeof privileges !== 'object') return 'Privileges must be an object'
   if (typeof show !== 'boolean') return 'Show must be a boolean'
   return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,6 +2091,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+    },
     "babel-plugin-transform-vue-jsx": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-4.0.1.tgz",
@@ -2211,8 +2216,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -3333,9 +3337,9 @@
       }
     },
     "connect-history-api-fallback": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
     "console-browserify": {
@@ -4027,7 +4031,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -4108,7 +4112,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -4121,7 +4125,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -4716,8 +4720,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -6032,7 +6035,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6053,12 +6057,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6073,17 +6079,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6200,7 +6209,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6212,6 +6222,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6226,6 +6237,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6233,12 +6245,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6257,6 +6271,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6337,7 +6352,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6349,6 +6365,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6434,7 +6451,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6470,6 +6488,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6489,6 +6508,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6532,12 +6552,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6776,9 +6798,9 @@
       }
     },
     "handle-thing": {
-      "version": "1.2.5",
-      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+      "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
       "dev": true
     },
     "har-schema": {
@@ -7138,7 +7160,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -7319,9 +7341,9 @@
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -8329,7 +8351,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
       "requires": {
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
@@ -8339,8 +8360,7 @@
         "json5": {
           "version": "0.5.1",
           "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         }
       }
     },
@@ -9173,6 +9193,11 @@
       "requires": {
         "lower-case": "^1.1.1"
       }
+    },
+    "node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc="
     },
     "node-forge": {
       "version": "0.7.5",
@@ -13041,6 +13066,15 @@
       "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og=",
       "dev": true
     },
+    "pdfjs-dist": {
+      "version": "2.0.943",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz",
+      "integrity": "sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==",
+      "requires": {
+        "node-ensure": "^0.0.0",
+        "worker-loader": "^2.0.0"
+      }
+    },
     "pdfkit": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.8.3.tgz",
@@ -14021,6 +14055,11 @@
         "unpipe": "1.0.0"
       }
     },
+    "raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -14657,7 +14696,6 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
       "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-      "dev": true,
       "requires": {
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0"
@@ -14666,8 +14704,7 @@
         "ajv-keywords": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-          "dev": true
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
         }
       }
     },
@@ -15211,52 +15248,73 @@
       "dev": true
     },
     "spdy": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+      "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
         "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
         "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "spdy-transport": "^3.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
     "spdy-transport": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
-      "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
         "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -16846,6 +16904,22 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-pdf": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/vue-pdf/-/vue-pdf-4.0.6.tgz",
+      "integrity": "sha512-3ay68wqmtwLFKHXNLgIjxv8mbXg/o2qjDg/J7lj/Ad9RQftj0NtddZEyK1lucmGAtg2b1nrEWE/fq6LY/tfk9A==",
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "pdfjs-dist": "2.0.943",
+        "raw-loader": "^0.5.1",
+        "vue-resize-sensor": "^2.0.0"
+      }
+    },
+    "vue-resize-sensor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vue-resize-sensor/-/vue-resize-sensor-2.0.0.tgz",
+      "integrity": "sha512-W+y2EAI/BxS4Vlcca9scQv8ifeBFck56DRtSwWJ2H4Cw1GLNUYxiZxUHHkuzuI5JPW/cYtL1bPO5xPyEXx4LmQ=="
+    },
     "vue-router": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.2.tgz",
@@ -17168,9 +17242,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
-      "integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+      "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -17192,21 +17266,23 @@
         "portfinder": "^1.0.9",
         "schema-utils": "^1.0.0",
         "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
         "serve-index": "^1.7.2",
         "sockjs": "0.3.19",
         "sockjs-client": "1.3.0",
-        "spdy": "^3.4.1",
+        "spdy": "^4.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^5.1.0",
+        "url": "^0.11.0",
         "webpack-dev-middleware": "3.4.0",
         "webpack-log": "^2.0.0",
         "yargs": "12.0.2"
       },
       "dependencies": {
         "ajv-keywords": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+          "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
           "dev": true
         },
         "ansi-regex": {
@@ -17224,21 +17300,6 @@
             "xregexp": "4.0.0"
           }
         },
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -17247,12 +17308,6 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
@@ -17280,31 +17335,37 @@
           }
         },
         "mem": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+          "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^1.0.0",
-            "p-is-promise": "^1.1.0"
+            "p-is-promise": "^2.0.0"
           }
         },
         "os-locale": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "^0.10.0",
+            "execa": "^1.0.0",
             "lcid": "^2.0.0",
             "mem": "^4.0.0"
           }
         },
-        "p-limit": {
+        "p-is-promise": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+          "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -17338,7 +17399,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -17936,6 +17997,15 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "roboto-fontface": "*",
     "serverless-http": "^1.8.0",
     "vue": "^2.5.17",
+    "vue-pdf": "^4.0.6",
     "vue-router": "^3.0.1",
     "vuetify": "^1.3.0",
     "vuex": "^3.0.1",

--- a/sample.csv
+++ b/sample.csv
@@ -1,2 +1,2 @@
 name,abbreviation,gender,languageGroup,show,privileges.bibleReading,privileges.ministryVideo,privileges.initialCall,privileges.initialCallAssist,privileges.returnVisit,privileges.returnVisitAssist,privileges.bibleStudy,privileges.bibleStudyAssist,privileges.studentTalk,privileges.chairman,appointment,privileges.chairman,privileges.highlights,privileges.gems,privileges.serviceTalk,privileges.congregationBibleStudy,privileges.reader,privileges.prayer
-Ben Jones,Be. Jones,Male,English,Y,Y,Y,Y,Y,Y,Y,Y,Y,,,Brother,,,,,,Y,Y
+Ben Jones,Be. Jones,Male,en,Y,Y,Y,Y,Y,Y,Y,Y,Y,,,Brother,,,,,,Y,Y

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -35,10 +35,10 @@ export default {
   schedule: {
     week: ({ date }) => api.get(`/schedule/week/${date}`),
     month: ({ month }) => api.get(`/schedule/month/${month}`),
-    scrape: ({ weekID }) => api.put(`/schedule/scrape/`, { weekID }),
-    updateAssignment: ({ weekID, name, assignment }) => api.put(`/schedule/updateAssignment`, { weekID, name, assignment }),
-    updateWeekType: ({ weekID, type }) => api.put(`/schedule/updateWeekType`, { weekID, type }),
-    updateCOName: ({ weekID, name }) => api.put(`/schedule/updateCOName`, { weekID, name }),
-    updateCOTitle: ({ weekID, title }) => api.put(`/schedule/updateCOTitle`, { weekID, title })
+    scrape: ({ weekID, language }) => api.put(`/schedule/scrape/`, { weekID, language }),
+    updateAssignment: ({ weekID, language, name, assignment }) => api.put(`/schedule/updateAssignment`, { weekID, language, name, assignment }),
+    updateWeekType: ({ weekID, language, type }) => api.put(`/schedule/updateWeekType`, { weekID, language, type }),
+    updateCOName: ({ weekID, language, name }) => api.put(`/schedule/updateCOName`, { weekID, language, name }),
+    updateCOTitle: ({ weekID, language, title }) => api.put(`/schedule/updateCOTitle`, { weekID, language, title })
   }
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -37,6 +37,7 @@ export default {
     month: ({ month }) => api.get(`/schedule/month/${month}`),
     scrape: ({ weekID, language }) => api.put(`/schedule/scrape/`, { weekID, language }),
     updateAssignment: ({ weekID, language, name, assignment }) => api.put(`/schedule/updateAssignment`, { weekID, language, name, assignment }),
+    deleteAssignment: ({ weekID, language, name }) => api.put(`/schedule/deleteAssignment`, { weekID, language, name }),
     updateWeekType: ({ weekID, language, type }) => api.put(`/schedule/updateWeekType`, { weekID, language, type }),
     updateCOName: ({ weekID, language, name }) => api.put(`/schedule/updateCOName`, { weekID, language, name }),
     updateCOTitle: ({ weekID, language, title }) => api.put(`/schedule/updateCOTitle`, { weekID, language, title })

--- a/src/components/AssigneeSelect.vue
+++ b/src/components/AssigneeSelect.vue
@@ -7,7 +7,7 @@
       no-data-text="No Assignees Available"
       :label="label"
       :loading="loading"
-      :disabled="disabled"
+      :disabled="inputDisabled"
       :items="items"
       :value="value"
       @input="onInput"
@@ -19,6 +19,7 @@
         small
         outline
         color="primary"
+        :disabled="inputDisabled"
         @click="onToggleLanguage"
       >
         <VIcon small v-text="restrictLanguage ? 'person' : 'group'" />
@@ -39,7 +40,8 @@ export default {
   props: {
     value: { type: String, default: '' },
     label: { type: String, required: true },
-    type: { type: String, default: '' }
+    type: { type: String, default: '' },
+    disabled: { type: Boolean, required: true }
   },
 
   data () {
@@ -54,13 +56,13 @@ export default {
       loading: 'congregation/loading',
       language: 'schedule/language'
     }),
-    disabled () {
-      const { type } = this
-      return !(PRIVILEGES.some(p => p.key === type))
+    inputDisabled () {
+      const { type, disabled } = this
+      return disabled || !(PRIVILEGES.some(p => p.key === type))
     },
     privilegedMembers () {
-      const { disabled, activeMembers, type, language, restrictLanguage } = this
-      if (disabled) return []
+      const { inputDisabled, activeMembers, type, language, restrictLanguage } = this
+      if (inputDisabled) return []
       return activeMembers.filter(({ privileges, languageGroup }) => {
         if (restrictLanguage && languageGroup !== language) return false
         return privileges[type]

--- a/src/components/PDFPreview.vue
+++ b/src/components/PDFPreview.vue
@@ -12,6 +12,7 @@
             :disabled="!downloadSrc"
             :href="downloadSrc"
             :download="downloadTitle"
+            @click="onDownload"
           >
             Download
             <VIcon right dark>
@@ -72,6 +73,7 @@ export default {
   data () {
     return {
       src: null,
+      downloadBlob: null,
       downloadSrc: null,
       numPages: 0
     }
@@ -96,10 +98,12 @@ export default {
     pdf (val) {
       if (!val) {
         this.src = null
+        this.downloadBlob = null
         this.downloadSrc = null
         return
       }
       val.getBlob(blob => {
+        this.downloadBlob = blob
         const dataUrl = URL.createObjectURL(blob)
         this.downloadSrc = dataUrl
         this.src = PDF.createLoadingTask(dataUrl)
@@ -109,6 +113,12 @@ export default {
   },
 
   methods: {
+    onDownload () {
+      // fallback for Edge/IE, which refuse to download a dataURI link
+      if (navigator && navigator.msSaveOrOpenBlob) {
+        navigator.msSaveOrOpenBlob(this.downloadBlob, this.downloadTitle)
+      }
+    },
     onClose () {
       this.$emit('input', false)
     }

--- a/src/components/Schedule/ScheduleAssignment.vue
+++ b/src/components/Schedule/ScheduleAssignment.vue
@@ -1,14 +1,24 @@
 <template>
   <VHover>
     <div slot-scope="{ hover }">
-      <VListTile class="py-2" :class="{ grey: !assignment.details }">
+      <VListTile class="py-2" :class="{ grey: !assignment.details, 'blue lighten-5': assignment.inherit || assignment.stream }">
         <VListTileContent>
-          <VListTileTitle v-text="assignment.displayName" />
+          <VListTileTitle>
+            <span v-text="assignment.displayName" />
+            <span v-if="assignment.inherit" class="primary--text font-weight-bold">
+              (English)
+            </span>
+          </VListTileTitle>
           <VListTileSubTitle v-if="!assignment.details">
             No Assignment Found
           </VListTileSubTitle>
           <template v-else>
-            <VListTileSubTitle>
+            <VListTileSubTitle v-if="assignment.details.stream">
+              <VChip small color="primary" class="white--text">
+                Streaming
+              </VChip>
+            </VListTileSubTitle>
+            <VListTileSubTitle v-else>
               <ScheduleAssignee :assignee="assignment.details.assignee" />
               <ScheduleAssignee v-if="hasAssistant" assistant :assignee="assignment.details.assistant" />
             </VListTileSubTitle>

--- a/src/components/Schedule/ScheduleWeek.vue
+++ b/src/components/Schedule/ScheduleWeek.vue
@@ -174,27 +174,13 @@
         <VCardText>
           <VContainer grid-list-md>
             <VLayout wrap>
-              <VFlex
-                xs12
-                md6
-                sm4
-              >
+              <VFlex :class="fieldClass">
                 <AssigneeSelect v-model="editAssignment.assignee" label="Assignee" :type="editAssignment.type" />
               </VFlex>
-              <VFlex
-                v-if="['initialCall', 'returnVisit', 'bibleStudy'].includes(editAssignment.type)"
-                xs12
-                md6
-                sm4
-              >
+              <VFlex v-if="['initialCall', 'returnVisit', 'bibleStudy'].includes(editAssignment.type)" :class="fieldClass">
                 <AssigneeSelect v-model="editAssignment.assistant" label="Assistant" :type="editAssignment.type + 'Assist'" />
               </VFlex>
-              <VFlex
-                v-if="editName.includes('studentTalk')"
-                xs12
-                md6
-                sm4
-              >
+              <VFlex v-if="editName.includes('studentTalk')" :class="fieldClass">
                 <VSelect
                   v-model="editAssignment.type"
                   label="Type"
@@ -207,28 +193,13 @@
                   ]"
                 />
               </VFlex>
-              <VFlex
-                v-if="!(['chairman', 'prayer', 'gems', 'reader'].includes(editAssignment.type))"
-                xs12
-                md6
-                sm4
-              >
+              <VFlex v-if="!(['chairman', 'prayer', 'gems', 'reader'].includes(editAssignment.type))" :class="fieldClass">
                 <VTextField v-model="editAssignment.title" label="Title" />
               </VFlex>
-              <VFlex
-                v-if="['bibleReading', 'initialCall', 'returnVisit', 'bibleStudy', 'studentTalk'].includes(editAssignment.type)"
-                xs12
-                md6
-                sm4
-              >
+              <VFlex v-if="['bibleReading', 'initialCall', 'returnVisit', 'bibleStudy', 'studentTalk'].includes(editAssignment.type)" :class="fieldClass">
                 <VTextField v-model="editAssignment.studyPoint" label="Study Point" />
               </VFlex>
-              <VFlex
-                v-if="!(['chairman', 'prayer', 'reader'].includes(editAssignment.type))"
-                xs12
-                md6
-                sm4
-              >
+              <VFlex v-if="!(['chairman', 'prayer', 'reader'].includes(editAssignment.type))" :class="fieldClass">
                 <VTextField v-model="editAssignment.time" label="Time" />
               </VFlex>
             </VLayout>
@@ -312,6 +283,7 @@ export default {
   data () {
     return {
       WEEK_TYPES,
+      fieldClass: 'xs12 md6 xl4',
       localWeek: { _id: null, loaded: false },
       loadError: false,
       scrapeLoading: false,

--- a/src/components/Schedule/ScheduleWeek.vue
+++ b/src/components/Schedule/ScheduleWeek.vue
@@ -220,6 +220,14 @@
           </VContainer>
         </VCardText>
         <VCardActions>
+          <VBtn
+            flat
+            color="error"
+            :disabled="editLoading"
+            @click="deleteEditor"
+          >
+            DELETE
+          </VBtn>
           <VSpacer />
           <VBtn
             flat
@@ -384,6 +392,7 @@ export default {
       loadWeek: 'schedule/loadWeek',
       scrapeWeek: 'schedule/scrapeWeek',
       updateAssignment: 'schedule/updateAssignment',
+      deleteAssignment: 'schedule/deleteAssignment',
       updateWeekType: 'schedule/updateWeekType',
       updateCOName: 'schedule/updateCOName',
       updateCOTitle: 'schedule/updateCOTitle'
@@ -428,6 +437,21 @@ export default {
       if (!assignment.type) assignment.type = ASSIGNMENT_TYPE_MAP[name]
       this.editAssignment = assignment
       this.editDialog = true
+    },
+    deleteEditor () {
+      this.editLoading = true
+      this.deleteAssignment({
+        weekID: this.localWeek._id,
+        name: this.editName
+      })
+        .then(this.loadLocalWeek)
+        .then(this.closeEditor)
+        .catch(err => {
+          console.error(err)
+        })
+        .finally(() => {
+          this.editLoading = false
+        })
     },
     closeEditor () {
       this.editDialog = false

--- a/src/components/Schedule/ScheduleWeek.vue
+++ b/src/components/Schedule/ScheduleWeek.vue
@@ -4,7 +4,7 @@
       <VToolbarTitle v-text="prettyDate" />
       <VSpacer />
       <VMenu
-        v-if="localWeek.loaded"
+        v-if="localWeek.loaded && !localWeek.unavailable"
         v-model="settingsMenu"
         lazy
         left
@@ -312,7 +312,7 @@ export default {
   data () {
     return {
       WEEK_TYPES,
-      localWeek: { _id: null, type: 0, loaded: false },
+      localWeek: { _id: null, loaded: false },
       loadError: false,
       scrapeLoading: false,
       scrapeError: false,
@@ -342,7 +342,7 @@ export default {
       },
       set (val) {
         const prev = this.weekType
-        this.week.type = val
+        this.$set(this.week, 'type', val)
         // wait for the animation to finish
         setTimeout(() => {
           if (!window.confirm('Are you sure you want to change the week type? All items may be unassigned.')) {

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -7,13 +7,42 @@
     <VSpacer />
     <VToolbarItems>
       <VBtn
+        v-if="!loggedIn"
         flat
         :disabled="loading"
         :loading="loading"
-        @click="onButtonClick"
+        @click="onLogin"
       >
-        {{ loggedIn ? 'Logout' : 'Login' }}
+        Login
       </VBtn>
+      <VMenu
+        v-else
+        offset-y
+        :close-on-content-click="false"
+        :min-width="200"
+        :max-width="200"
+      >
+        <VBtn slot="activator" icon>
+          <VIcon>settings</VIcon>
+        </VBtn>
+        <VCard class="pa-3">
+          <VSelect
+            v-model="languageModel"
+            label="Language"
+            :items="items"
+          />
+          <VBtn
+            flat
+            block
+            color="error"
+            :disabled="loading"
+            :loading="loading"
+            @click="onLogout"
+          >
+            Logout
+          </VBtn>
+        </VCard>
+      </VMenu>
     </VToolbarItems>
   </VToolbar>
 </template>
@@ -21,20 +50,31 @@
 <script>
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 import routes from '@/router/routes'
+import { SUPPORTED_LANGUAGES } from '@/constants'
 
 export default {
   name: 'Toolbar',
 
   data () {
     return {
-      loading: false
+      loading: false,
+      items: SUPPORTED_LANGUAGES
     }
   },
 
   computed: {
     ...mapGetters({
-      loggedIn: 'auth/hasToken'
+      loggedIn: 'auth/hasToken',
+      language: 'schedule/language'
     }),
+    languageModel: {
+      get () {
+        return this.language
+      },
+      set (val) {
+        this.updateLanguage(val)
+      }
+    },
     title () {
       switch (this.$route.name) {
         case routes.HOME:
@@ -61,13 +101,13 @@ export default {
     }),
     ...mapMutations({
       toggleDrawer: 'drawer/TOGGLE_OPEN',
-      alert: 'alert/UPDATE_ALERT'
+      alert: 'alert/UPDATE_ALERT',
+      updateLanguage: 'schedule/UPDATE_LANGUAGE'
     }),
-    onButtonClick () {
-      if (!this.loggedIn) {
-        this.$router.push({ name: routes.LOGIN })
-        return
-      }
+    onLogin () {
+      this.$router.push({ name: routes.LOGIN })
+    },
+    onLogout () {
       this.loading = true
       this.logout()
         .then(() => {

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -32,7 +32,6 @@
             :items="items"
           />
           <VBtn
-            flat
             block
             color="error"
             :disabled="loading"

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,7 +41,10 @@ export const APPOINTMENTS = ['None', 'Brother', 'Sister', 'Ministerial Servant',
 
 export const GENDERS = ['Male', 'Female']
 
-export const LANGUAGE_GROUPS = ['English', 'Portuguese']
+export const SUPPORTED_LANGUAGES = [
+  { text: 'English', value: 'en' },
+  { text: 'Portuguese', value: 'tpo' }
+]
 
 export const WEEK_TYPES = {
   normal: { label: 'Normal', value: 0 },

--- a/src/plugins/pdfMake.js
+++ b/src/plugins/pdfMake.js
@@ -7,6 +7,74 @@ import { COLORS, WEEK_TYPES } from '@/constants'
 pdfMake.vfs = pdfFonts.pdfMake.vfs
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const ASSIGNMENT_SLIP_TRANSLATIONS = {
+  en: {
+    verticalPadding: 32,
+    defaultRoom: 'mainHall',
+    title: 'OUR CHRISTIAN LIFE AND MINISTRY MEETING ASSIGNMENT',
+    name: 'Name',
+    assistant: 'Assistant',
+    date: 'Date',
+    studyPoint: 'Study Point',
+    assignment: 'Assignment',
+    bibleReading: 'Bible reading',
+    initialCall: 'Initial call',
+    firstReturnVisit: 'First return visit',
+    secondReturnVisit: 'Second return visit',
+    first: 'First',
+    second: 'Second',
+    givenIn: 'To be given in',
+    mainHall: 'Main hall',
+    class1: 'Auxiliary classroom 1',
+    class2: 'Auxiliary classroom 2',
+    bibleStudy: 'Bible study',
+    studentTalk: 'Talk',
+    other: 'Other: ..................',
+    note: [
+      { text: 'Note to student: ', bold: true },
+      { text: 'The source material and study point for your assignment can be found in the ' },
+      { text: 'Life and Ministry Meeting Workbook. ', italics: true },
+      { text: 'Please work on the listed study point, which is discussed in the ' },
+      { text: 'Teaching ', italics: true },
+      { text: 'brochure. You should ' },
+      { text: 'bring your brochure, either printed or electronic, to the Life and Ministry Meeting.', bold: true }
+    ],
+    footer: 'S-89-E      10/18'
+  },
+  tpo: {
+    verticalPadding: 28,
+    defaultRoom: 'class1',
+    title: 'DESIGNAÇÃO PARA A REUNIÃO VIDA E MINISTÉRIO CRISTÃOS',
+    name: 'Nome',
+    assistant: 'Ajudante',
+    date: 'Data',
+    studyPoint: 'Ponto de Conselho',
+    assignment: 'Designação',
+    bibleReading: 'Leitura da Bíblia',
+    initialCall: 'Contacto Inicial',
+    firstReturnVisit: 'Primeira Revisita',
+    secondReturnVisit: 'Segunda Revisita',
+    first: 'Primeira',
+    second: 'Segunda',
+    givenIn: 'A ser apresentada no(a)',
+    mainHall: 'Salão principal',
+    class1: '1a Sala auxiliar',
+    class2: '2a Sala auxiliar',
+    bibleStudy: 'Estudo Bíblico',
+    studentTalk: 'Discurso',
+    other: 'Outra: ..................',
+    note: [
+      { text: 'Nota ao estudante: ', bold: true },
+      { text: 'A fonte de matéria para a sua designação encontra-se no ' },
+      { text: 'Manual de Atividades da Reunião Vida e Ministério. ', italics: true },
+      { text: 'Por favor, trabalhe o ponto de conselho que é designado, e que é abordado na brochura ' },
+      { text: 'Melhore a Sua Leitura e o Seu Ensino. ', italics: true },
+      { text: 'Deverá ' },
+      { text: 'trazer a sua brochura, quer impressa ou em formato electrónico para a Reunião Vida e Ministério.', bold: true }
+    ],
+    footer: 'S-89-TPO     10/18'
+  }
+}
 let timer
 
 function setTime (time) {
@@ -256,25 +324,25 @@ export function generateSchedule (weeks, month) {
   return pdfMake.createPdf(docDefinition)
 }
 
-function createSlip (assignment, date = '') {
+function createSlip (translation, assignment, date = '') {
   const { title, type, assignee, assistant, studyPoint } = assignment || {}
   const [y, m, d] = date.split('-')
   const prettyDate = [d, MONTHS[+m - 1], y].join(' ')
   return {
     width: '50%',
-    margin: [32, 32, 32, 32],
+    margin: [32, translation.verticalPadding, 32, translation.verticalPadding],
     stack: [
       {
-        text: 'OUR CHRISTIAN LIFE AND MINISTRY MEETING ASSIGNMENT',
+        text: translation.title,
         fontSize: 14,
         alignment: 'center',
         bold: true,
         margin: [0, 0, 0, 12]
       },
-      createAssignmentInput('Name:', getAssigneeName(assignee)),
-      createAssignmentInput('Assistant:', getAssigneeName(assistant)),
-      createAssignmentInput('Date:', prettyDate),
-      createAssignmentInput('Study Point:', studyPoint),
+      createAssignmentInput(translation.name + ':', getAssigneeName(assignee)),
+      createAssignmentInput(translation.assistant + ':', getAssigneeName(assistant)),
+      createAssignmentInput(translation.date + ':', prettyDate),
+      createAssignmentInput(translation.studyPoint + ':', studyPoint),
       {
         fontSize: 10,
         margin: [0, 8, 0, 16],
@@ -282,24 +350,24 @@ function createSlip (assignment, date = '') {
           {
             width: '55%',
             stack: [
-              { text: 'Assignment:', bold: true, margin: [0, 0, 0, 1] },
-              createAssignmentCheckbox('Bible reading', type === 'bibleReading'),
-              createAssignmentCheckbox('Initial call', type === 'initialCall'),
-              createAssignmentCheckbox('First return visit', title === 'First Return Visit'),
-              createAssignmentCheckbox('Second return visit', title === 'Second Return Visit'),
-              { text: 'To be given in:', bold: true, margin: [0, 4, 0, 1] },
-              createAssignmentCheckbox('Main hall', !!assignment),
-              createAssignmentCheckbox('Auxiliary classroom 1'),
-              createAssignmentCheckbox('Auxiliary classroom 2')
+              { text: translation.assignment + ':', bold: true, margin: [0, 0, 0, 1] },
+              createAssignmentCheckbox(translation.bibleReading, type === 'bibleReading'),
+              createAssignmentCheckbox(translation.initialCall, type === 'initialCall'),
+              createAssignmentCheckbox(translation.firstReturnVisit, type === 'returnVisit' && title.includes(translation.first)),
+              createAssignmentCheckbox(translation.secondReturnVisit, type === 'returnVisit' && title.includes(translation.second)),
+              { text: translation.givenIn + ':', bold: true, margin: [0, 4, 0, 1] },
+              createAssignmentCheckbox(translation.mainHall, assignment && translation.defaultRoom === 'mainHall'),
+              createAssignmentCheckbox(translation.class1, assignment && translation.defaultRoom === 'class1'),
+              createAssignmentCheckbox(translation.class2, assignment && translation.defaultRoom === 'class2')
             ]
           },
           {
             width: '45%',
             margin: [0, 12, 0, 0],
             stack: [
-              createAssignmentCheckbox('Bible study', type === 'bibleStudy'),
-              createAssignmentCheckbox('Talk', type === 'studentTalk'),
-              createAssignmentCheckbox('Other: ..................')
+              createAssignmentCheckbox(translation.bibleStudy, type === 'bibleStudy'),
+              createAssignmentCheckbox(translation.studentTalk, type === 'studentTalk'),
+              createAssignmentCheckbox(translation.other)
             ]
           }
         ]
@@ -307,18 +375,10 @@ function createSlip (assignment, date = '') {
       {
         fontSize: 9,
         alignment: 'justify',
-        text: [
-          { text: 'Note to student: ', bold: true },
-          { text: 'The source material and study point for your assignment can be found in the ' },
-          { text: 'Life and Ministry Meeting Workbook. ', italics: true },
-          { text: 'Please work on the listed study point, which is discussed in the ' },
-          { text: 'Teaching ', italics: true },
-          { text: 'brochure. You should ' },
-          { text: 'bring your brochure, either printed or electronic, to the Life and Ministry Meeting.', bold: true }
-        ]
+        text: translation.note
       },
       {
-        text: 'S-89-E      10/18',
+        text: translation.footer,
         fontSize: 10,
         margin: [0, 8, 0, 0]
       }
@@ -410,6 +470,8 @@ export function generateAssignmentSlips (weeks, month) {
   const slips = []
   const VALID_TYPES = ['bibleReading', 'initialCall', 'returnVisit', 'bibleStudy', 'studentTalk']
   const language = store.getters['schedule/language']
+  const translation = ASSIGNMENT_SLIP_TRANSLATIONS[language]
+  if (!translation) throw new Error('Translations not created for the selected language')
   for (const baseWeek of weeks) {
     const { date } = baseWeek
     const week = baseWeek[language]
@@ -419,14 +481,14 @@ export function generateAssignmentSlips (weeks, month) {
     for (let i = 0; i <= 4; i++) {
       // treat index 0 as the bibleReading, else extract a student talk
       const talk = i === 0 ? assignments.bibleReading : assignments['studentTalk' + i]
-      if (!talk || !(VALID_TYPES.includes(talk.type))) continue
-      slips.push(createSlip(talk, date))
+      if (!talk || talk.inherit || !(VALID_TYPES.includes(talk.type))) continue
+      slips.push(createSlip(translation, talk, date))
     }
   }
 
   // complete the last page so there aren't blank slips
   while (slips.length % 4 !== 0) {
-    slips.push(createSlip())
+    slips.push(createSlip(translation))
   }
 
   // arrange the slips

--- a/src/plugins/pdfMake.js
+++ b/src/plugins/pdfMake.js
@@ -147,8 +147,11 @@ export function generateSchedule (weeks, month) {
   }
 
   stack.push(createScheduleSeparator(false))
-  weeks.forEach((week, index) => {
-    const { type, date, weeklyBibleReading, songs, assignments } = week
+  const language = store.getters['schedule/language']
+  weeks.forEach((baseWeek, index) => {
+    const { date } = baseWeek
+    const week = baseWeek[language] || {}
+    const { type, weeklyBibleReading, songs, assignments, coTitle, coName } = week
     const {
       openingPrayer,
       chairman,
@@ -224,7 +227,7 @@ export function generateSchedule (weeks, month) {
     if (type === WEEK_TYPES.coVisit.value) {
       livingTableRows.push(
         [timer, 'Review/Preview/Announcements (3 min.)', 'Chairman:', getScheduleAssignees(chairman), addTime(3)],
-        [timer, week.coTitle + ' (30 min.)', 'Circuit Overseer:', week.coName, addTime(30)],
+        [timer, coTitle + ' (30 min.)', 'Circuit Overseer:', coName, addTime(30)],
         [timer, songs[2], 'Prayer:', getScheduleAssignees(closingPrayer), addTime(5)]
       )
     } else {
@@ -397,14 +400,17 @@ export function generateAssignmentSlips (weeks, month) {
 
   const slips = []
   const VALID_TYPES = ['bibleReading', 'initialCall', 'returnVisit', 'bibleStudy', 'studentTalk']
-  for (const week of weeks) {
+  const language = store.getters['schedule/language']
+  for (const baseWeek of weeks) {
+    const { date } = baseWeek
+    const week = baseWeek[language] || {}
     const { type, assignments } = week
     if (type === WEEK_TYPES.assembly.value || type === WEEK_TYPES.memorial.value) continue
     for (let i = 0; i <= 4; i++) {
       // treat index 0 as the bibleReading, else extract a student talk
       const talk = i === 0 ? assignments.bibleReading : assignments['studentTalk' + i]
       if (!talk || !(VALID_TYPES.includes(talk.type))) continue
-      slips.push(createSlip(talk, week.date))
+      slips.push(createSlip(talk, date))
     }
   }
 

--- a/src/plugins/pdfMake.js
+++ b/src/plugins/pdfMake.js
@@ -150,7 +150,8 @@ export function generateSchedule (weeks, month) {
   const language = store.getters['schedule/language']
   weeks.forEach((baseWeek, index) => {
     const { date } = baseWeek
-    const week = baseWeek[language] || {}
+    const week = baseWeek[language]
+    if (!week) throw new Error('Week not created for the selected language')
     const { type, weeklyBibleReading, songs, assignments, coTitle, coName } = week
     const {
       openingPrayer,
@@ -403,7 +404,8 @@ export function generateAssignmentSlips (weeks, month) {
   const language = store.getters['schedule/language']
   for (const baseWeek of weeks) {
     const { date } = baseWeek
-    const week = baseWeek[language] || {}
+    const week = baseWeek[language]
+    if (!week) throw new Error('Week not created for the selected language')
     const { type, assignments } = week
     if (type === WEEK_TYPES.assembly.value || type === WEEK_TYPES.memorial.value) continue
     for (let i = 0; i <= 4; i++) {

--- a/src/plugins/pdfMake.js
+++ b/src/plugins/pdfMake.js
@@ -15,7 +15,8 @@ function setTime (time) {
 }
 
 function addTime (minutes) {
-  const toAdd = parseInt(/\d+/.exec(minutes)[0])
+  const mins = /\d+/.exec(minutes) || [0]
+  const toAdd = parseInt(mins[0])
   let [h, m] = timer.split(':').map(Number)
   m += toAdd
   if (m > 59) {
@@ -40,6 +41,7 @@ function getAssignmentTitle (assignment) {
 }
 
 function getScheduleAssignees (assignment) {
+  if (assignment.stream) return '(Video Stream)'
   let assignees = getAssigneeName(assignment.assignee, '-')
   if (['initialCall', 'returnVisit', 'bibleStudy'].includes(assignment.type)) {
     assignees += ' / ' + getAssigneeName(assignment.assistant, '-')
@@ -153,6 +155,12 @@ export function generateSchedule (weeks, month) {
     const week = baseWeek[language]
     if (!week) throw new Error('Week not created for the selected language')
     const { type, weeklyBibleReading, songs, assignments, coTitle, coName } = week
+    const assignmentMap = Object.entries(assignments)
+      .reduce((acc, [k, v]) => {
+        if (!v) return acc
+        const a = v.inherit ? baseWeek.en.assignments[k] : v
+        return Object.assign(acc, { [k]: a })
+      }, {})
     const {
       openingPrayer,
       chairman,
@@ -164,7 +172,7 @@ export function generateSchedule (weeks, month) {
       congregationBibleStudy,
       reader,
       closingPrayer
-    } = assignments
+    } = assignmentMap
 
     // Week Title & Information
     if (index > 0 && index % 2 === 0) stack.push(createScheduleSeparator(true))
@@ -205,7 +213,7 @@ export function generateSchedule (weeks, month) {
     stack.push(createScheduleSubheader('APPLY YOURSELF TO THE FIELD MINISTRY', COLORS.MINISTRY))
     const ministryTableRows = []
     for (let i = 1; i <= 4; i++) {
-      const studentTalk = assignments['studentTalk' + i]
+      const studentTalk = assignmentMap['studentTalk' + i]
       if (!studentTalk) {
         ministryTableRows.push(null)
         continue

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -19,6 +19,6 @@ export default new Vuex.Store({
     schedule
   },
   plugins: [createPersistedState({
-    paths: ['auth']
+    paths: ['auth', 'schedule.language']
   })]
 })

--- a/src/store/schedule.js
+++ b/src/store/schedule.js
@@ -54,6 +54,18 @@ const actions = {
         return week
       })
   },
+  deleteAssignment ({ commit, getters }, { weekID, name }) {
+    const { language } = getters
+    return api.schedule.deleteAssignment({ weekID, language, name })
+      .then(res => {
+        const { week, members } = res.data.result
+        commit('UPDATE_WEEK', week)
+        for (const member of members) {
+          commit('congregation/UPDATE_MEMBER', member, { root: true })
+        }
+        return week
+      })
+  },
   updateWeekType ({ commit, getters }, { weekID, type }) {
     const { language } = getters
     return api.schedule.updateWeekType({ weekID, language, type })

--- a/src/store/schedule.js
+++ b/src/store/schedule.js
@@ -33,7 +33,8 @@ const actions = {
         return weeks
       })
   },
-  scrapeWeek ({ commit }, { weekID, language }) {
+  scrapeWeek ({ commit, getters }, { weekID }) {
+    const { language } = getters
     return api.schedule.scrape({ weekID, language })
       .then(res => {
         const scrapedWeek = res.data.result
@@ -41,7 +42,8 @@ const actions = {
         return scrapedWeek
       })
   },
-  updateAssignment ({ commit }, { weekID, language, name, assignment }) {
+  updateAssignment ({ commit, getters }, { weekID, name, assignment }) {
+    const { language } = getters
     return api.schedule.updateAssignment({ weekID, language, name, assignment })
       .then(res => {
         const { week, members } = res.data.result
@@ -52,7 +54,8 @@ const actions = {
         return week
       })
   },
-  updateWeekType ({ commit }, { weekID, language, type }) {
+  updateWeekType ({ commit, getters }, { weekID, type }) {
+    const { language } = getters
     return api.schedule.updateWeekType({ weekID, language, type })
       .then(res => {
         const { week, members } = res.data.result
@@ -63,7 +66,8 @@ const actions = {
         return week
       })
   },
-  updateCOName ({ commit }, { weekID, language, name }) {
+  updateCOName ({ commit, getters }, { weekID, name }) {
+    const { language } = getters
     return api.schedule.updateCOName({ weekID, language, name })
       .then(res => {
         const week = res.data.result
@@ -71,7 +75,8 @@ const actions = {
         return week
       })
   },
-  updateCOTitle ({ commit }, { weekID, language, title }) {
+  updateCOTitle ({ commit, getters }, { weekID, title }) {
+    const { language } = getters
     return api.schedule.updateCOTitle({ weekID, language, title })
       .then(res => {
         const week = res.data.result

--- a/src/store/schedule.js
+++ b/src/store/schedule.js
@@ -33,16 +33,16 @@ const actions = {
         return weeks
       })
   },
-  scrapeWeek ({ commit }, { weekID }) {
-    return api.schedule.scrape({ weekID })
+  scrapeWeek ({ commit }, { weekID, language }) {
+    return api.schedule.scrape({ weekID, language })
       .then(res => {
         const scrapedWeek = res.data.result
         commit('UPDATE_WEEK', scrapedWeek)
         return scrapedWeek
       })
   },
-  updateAssignment ({ commit }, { weekID, name, assignment }) {
-    return api.schedule.updateAssignment({ weekID, name, assignment })
+  updateAssignment ({ commit }, { weekID, language, name, assignment }) {
+    return api.schedule.updateAssignment({ weekID, language, name, assignment })
       .then(res => {
         const { week, members } = res.data.result
         commit('UPDATE_WEEK', week)
@@ -52,8 +52,8 @@ const actions = {
         return week
       })
   },
-  updateWeekType ({ commit }, { weekID, type }) {
-    return api.schedule.updateWeekType({ weekID, type })
+  updateWeekType ({ commit }, { weekID, language, type }) {
+    return api.schedule.updateWeekType({ weekID, language, type })
       .then(res => {
         const { week, members } = res.data.result
         commit('UPDATE_WEEK', week)
@@ -63,16 +63,16 @@ const actions = {
         return week
       })
   },
-  updateCOName ({ commit }, { weekID, name }) {
-    return api.schedule.updateCOName({ weekID, name })
+  updateCOName ({ commit }, { weekID, language, name }) {
+    return api.schedule.updateCOName({ weekID, language, name })
       .then(res => {
         const week = res.data.result
         commit('UPDATE_WEEK', week)
         return week
       })
   },
-  updateCOTitle ({ commit }, { weekID, title }) {
-    return api.schedule.updateCOTitle({ weekID, title })
+  updateCOTitle ({ commit }, { weekID, language, title }) {
+    return api.schedule.updateCOTitle({ weekID, language, title })
       .then(res => {
         const week = res.data.result
         commit('UPDATE_WEEK', week)

--- a/src/store/schedule.js
+++ b/src/store/schedule.js
@@ -4,11 +4,13 @@ const state = {
   weeks: [],
   month: [],
   loadedMonth: '',
-  selectedAssignee: ''
+  selectedAssignee: '',
+  language: 'en'
 }
 
 const getters = {
-  selectedAssignee: state => state.selectedAssignee
+  selectedAssignee: state => state.selectedAssignee,
+  language: state => state.language
 }
 
 const actions = {
@@ -95,6 +97,9 @@ const mutations = {
   },
   UPDATE_SELECTED_ASSIGNEE (state, payload) {
     Object.assign(state, { selectedAssignee: payload })
+  },
+  UPDATE_LANGUAGE (state, payload) {
+    Object.assign(state, { language: payload })
   }
 }
 

--- a/src/views/Congregation.vue
+++ b/src/views/Congregation.vue
@@ -37,7 +37,7 @@
                   <VSelect v-model="editMember.appointment" label="Appointment" :items="APPOINTMENTS" />
                 </VFlex>
                 <VFlex xs12 sm6 md4>
-                  <VSelect v-model="editMember.languageGroup" label="Language Group" :items="LANGUAGE_GROUPS" />
+                  <VSelect v-model="editMember.languageGroup" label="Language Group" :items="SUPPORTED_LANGUAGES" />
                 </VFlex>
                 <VFlex xs12 sm6 md4>
                   <VCheckbox v-model="editMember.show" label="Show On Schedule" />
@@ -95,7 +95,7 @@
           <td v-text="props.item.abbreviation" />
           <td v-text="props.item.gender" />
           <td v-text="props.item.appointment" />
-          <td v-text="props.item.languageGroup" />
+          <td v-text="languageGroups[props.item.languageGroup]" />
           <td class="text-xs-center">
             <BooleanIcon :value="props.item.show" />
           </td>
@@ -148,7 +148,7 @@ import BooleanIcon from '@/components/BooleanIcon'
 import {
   GENDERS,
   APPOINTMENTS,
-  LANGUAGE_GROUPS,
+  SUPPORTED_LANGUAGES,
   PRIVILEGES
 } from '@/constants'
 
@@ -161,8 +161,9 @@ export default {
     return {
       GENDERS,
       APPOINTMENTS,
-      LANGUAGE_GROUPS,
+      SUPPORTED_LANGUAGES,
       PRIVILEGES,
+      languageGroups: SUPPORTED_LANGUAGES.reduce((acc, { text, value }) => Object.assign(acc, { [value]: text }), {}),
       headers: [
         { text: 'Name', value: 'name' },
         { text: 'Abbreviation', value: 'abbreviation' },
@@ -183,7 +184,7 @@ export default {
         abbreviation: '',
         gender: GENDERS[0],
         appointment: APPOINTMENTS[0],
-        languageGroup: LANGUAGE_GROUPS[0],
+        languageGroup: SUPPORTED_LANGUAGES[0],
         show: true,
         privileges: {}
       }
@@ -223,7 +224,7 @@ export default {
         abbreviation: '',
         gender: GENDERS[0],
         appointment: APPOINTMENTS[0],
-        languageGroup: LANGUAGE_GROUPS[0],
+        languageGroup: SUPPORTED_LANGUAGES[0],
         show: true,
         privileges: {}
       })


### PR DESCRIPTION
Does the worst part of the work for #18 

Reorganises the database structure in order to allow for viewing completely different schedules based on a chosen program type

This will be deployed at stable stages until fully merged

Still to be done:

- Web Scraping for Portuguese
- Display of current language in toolbar
- PDFs for Portuguese
- Option to 'inherit' an assignment from another language
- Refactor CO support to be an actual assignment so that inheritance will be easier