### PR TITLE
Scraper Fix for 2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oclm-planner",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "serve": "npm-run-all --parallel serve:**",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -69,6 +69,14 @@ export default Vue.extend({
     changes (): IChange[] {
       return [
         {
+          version: '1.1.3',
+          date: '20 Nov 2019',
+          summary: 'Scraper Fix for 2020',
+          updates: [
+            { title: 'Fixes', items: ['Week downloader/scraper now adapted to work with site changes for 2020'] }
+          ]
+        },
+        {
           version: '1.1.2',
           date: '30 Oct 2019',
           summary: 'Updates for Gems & UX improvements',


### PR DESCRIPTION
Update scraping constructor for `en` seeing as WOL is not longer being updated seemingly.

* Closes #97 